### PR TITLE
Switch order of literals to prevent NullPointerException 

### DIFF
--- a/app/src/main/java/com/dineout/code/hall/Adapter.java
+++ b/app/src/main/java/com/dineout/code/hall/Adapter.java
@@ -244,17 +244,17 @@ public class Adapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> {
             TableID.setText("Id: ");
             Capacity.setText(tables.get(position).getCapacity());
             TableCapacity.setText("Capacity: ");
-            if (tables.get(position).getStatus().equals("Booked")) {
+            if ("Booked".equals(tables.get(position).getStatus())) {
                 status.setImageResource(R.drawable.booked);
                 free.setEnabled(true);
                 occupy.setEnabled(false);
                 booked.setEnabled(false);
-            } else if (tables.get(position).getStatus().equals("Occupied")) {
+            } else if ("Occupied".equals(tables.get(position).getStatus())) {
                 status.setImageResource(R.drawable.occupy);
                 free.setEnabled(true);
                 occupy.setEnabled(false);
                 booked.setEnabled(false);
-            } else if (tables.get(position).getStatus().equals("Free")) {
+            } else if ("Free".equals(tables.get(position).getStatus())) {
                 status.setImageResource(R.drawable.free);
                 free.setEnabled(false);
                 occupy.setEnabled(true);
@@ -573,15 +573,15 @@ public class Adapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> {
             TabletID.setText("Tablet ID: ");
             Status.setText("Status: ");
             s.setText(tablets.get(position).getStatus());
-            if(tablets.get(position).getStatus().equals("In Use"))
+            if("In Use".equals(tablets.get(position).getStatus()))
             {
                 Assign.setEnabled(false);
             }
-            else if(tablets.get(position).getStatus().equals("Broken"))
+            else if("Broken".equals(tablets.get(position).getStatus()))
             {
                 Assign.setEnabled(false);
             }
-            else if(tablets.get(position).getStatus().equals("Issue"))
+            else if("Issue".equals(tablets.get(position).getStatus()))
             {
                 Assign.setEnabled(false);
             }

--- a/app/src/main/java/com/dineout/code/reporting/EndOfDay_EventHandler.java
+++ b/app/src/main/java/com/dineout/code/reporting/EndOfDay_EventHandler.java
@@ -134,27 +134,27 @@ public class EndOfDay_EventHandler
 
     public int GetWeekDayIndex(String w)
     {
-        if(w.equals("Monday"))
+        if("Monday".equals(w))
         {
             return 3;
         }
-        else if(w.equals("Tuesday"))
+        else if("Tuesday".equals(w))
         {
             return 4;
         }
-        else if(w.equals("Wednesday"))
+        else if("Wednesday".equals(w))
         {
             return 5;
         }
-        else if(w.equals("Thursday"))
+        else if("Thursday".equals(w))
         {
             return 6;
         }
-        else if(w.equals("Friday"))
+        else if("Friday".equals(w))
         {
             return 7;
         }
-        else if(w.equals("Saturday"))
+        else if("Saturday".equals(w))
         {
             return 1;
         }


### PR DESCRIPTION
This change defensively switches the order of literals in comparison expressions to ensure that no null pointer exceptions are unexpectedly thrown. Runtime exceptions especially can cause exceptional and unexpected code paths to be taken, and this can result in unexpected behavior. 

Both simple vulnerabilities (like information disclosure) and complex vulnerabilities (like business logic flaws) can take advantage of these unexpected code paths.

Our changes look something like this:

```diff
  String fieldName = header.getFieldName();
  String fieldValue = header.getFieldValue();
- if(fieldName.equals("requestId")) {
+ if("requestId".equals(fieldName)) {
    logRequest(fieldValue);
  }
```

<details>
  <summary>More reading</summary>

  * [http://cwe.mitre.org/data/definitions/476.html](http://cwe.mitre.org/data/definitions/476.html)
  * [https://en.wikibooks.org/wiki/Java_Programming/Preventing_NullPointerException](https://en.wikibooks.org/wiki/Java_Programming/Preventing_NullPointerException)
  * [https://rules.sonarsource.com/java/RSPEC-1132/](https://rules.sonarsource.com/java/RSPEC-1132/)
</details>

Powered by: [pixeebot](https://docs.pixee.ai/installing/) (codemod ID: [pixee:java/switch-literal-first](https://docs.pixee.ai/codemods/java/pixee_java_switch-literal-first)) ![](https://d1zaessa2hpsmj.cloudfront.net/pixel/v1/track?writeKey=2PI43jNm7atYvAuK7rJUz3Kcd6A&event=DRIP_PR%7CPixee-Bot-zc%2FRestaurant-Management-System%7C71a7459c528a1c6c928ff472aef4013f00dd8d2b)

<!--{"type":"DRIP","codemod":"pixee:java/switch-literal-first"}-->